### PR TITLE
xButton device extension

### DIFF
--- a/app/pages/index-items.coffee
+++ b/app/pages/index-items.coffee
@@ -71,6 +71,11 @@ $(document).on( "pagebeforecreate", (event) ->
       buttons = []
       if @device.config.xLink
         buttons.push """<a href="#{@device.config.xLink}" target="_blank">Link</a>"""
+      if @device.config.xButton
+        buttons.push """
+          <a href="#" id="to-device-xButton"
+          data-deviceId="#{@device.id}">#{@device.config.xButton}</a>
+        """
       if @device.hasAttibuteWith( (attr) => attr.type in ["number", "boolean"])
         buttons.push """  
           <a href="#" id="to-graph-page"

--- a/app/pages/index.coffee
+++ b/app/pages/index.coffee
@@ -449,6 +449,18 @@ $(document).on("pagecreate", '#index', tc (event) ->
     jQuery.mobile.pageParams = {action: 'update', device: device, back: '#index'}
     jQuery.mobile.changePage '#edit-device-page', transition: 'slide'
 
+  $(document).on "vclick", '#to-device-xButton', ->
+    deviceId = $('#to-device-xButton').attr('data-deviceId')
+    device = pimatic.getDeviceById(deviceId)
+    device.rest.xButton({})
+    .done( (response) =>
+      if response.success
+        eval(response.result)
+      else
+        throw new Error("xButton call failed: #{response.result}!")
+    )
+    .fail(ajaxAlertFail)
+
   return
 )
 


### PR DESCRIPTION
![xbutton](https://cloud.githubusercontent.com/assets/4578458/22771966/46e13f9a-ee9a-11e6-9028-63130c2c014c.png)

Thanks for the great pimatic framework! This PR adds a device specific button to the frontend which, in opposite to the static xLink extension, is evaluated at run time by a custom device action called "xButton" which has to be provided by the device class. I want to use it in the [pimatic-phone](https://github.com/bstrebel/pimatic-phone) plugin to display the current device location in a browser tab or popup window with a map from Google or Open Street Map. I'm sure, this extension is of interest  for other plugin developers if they want to make use of run time device states or attribute values. It would be great to have it integrated into the core product. Thanks!
